### PR TITLE
Add containerip,port to more ipsets according to service name and tags

### DIFF
--- a/netfilter/helpers.go
+++ b/netfilter/helpers.go
@@ -46,9 +46,16 @@ func ipsetRun(ipcmd string) error {
 }
 
 func ipsetHost(command string, set string, ip string, proto string, port string) error {
+	err := ipsetInitWithHash(set, "ip,port")
+	if err != nil {
+		log.Println("ipsetHost() could not create ipset: ", set)
+		log.Println("Error: ", err)
+		return err
+	}
+
 	cmd := "-! " + command + " " + set + " " + ip + "," + proto + ":" + port
 	log.Println("ipsetHost()", cmd)
-	err := ipsetRun(cmd)
+	err = ipsetRun(cmd)
 	if err != nil {
 		return err
 	}
@@ -81,7 +88,20 @@ func iptablesInit(chain string, set string) error {
 }
 
 func ipsetInit(set string) error {
-	err := ipsetRun("-! create " + set + " hash:ip,port family inet6")
+	err := ipsetInitAndFlushWithHash(set, "ip,port")
+	return err
+}
+
+func ipsetInitWithHash(set string, hash string) error {
+	err := ipsetRun("-! create " + set + " hash:" + hash + " family inet6")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ipsetInitAndFlushWithHash(set string, hash string) error {
+	err := ipsetInitWithHash(set, hash)
 	if err != nil {
 		return err
 	}

--- a/netfilter/helpers.go
+++ b/netfilter/helpers.go
@@ -45,21 +45,27 @@ func ipsetRun(ipcmd string) error {
 	return nil
 }
 
-func ipsetHost(command string, set string, ip string, proto string, port string) error {
+func ipsetHost(command string, set string, ip string, proto string, port string, timeout string) error {
 	err := ipsetInitWithHash(set, "ip,port")
 	if err != nil {
-		log.Println("ipsetHost() could not create ipset: ", set)
-		log.Println("Error: ", err)
 		return err
 	}
 
 	cmd := "-! " + command + " " + set + " " + ip + "," + proto + ":" + port
+	if timeout != "" {
+		cmd = cmd + " timeout " + timeout
+	}
+
 	log.Println("ipsetHost()", cmd)
 	err = ipsetRun(cmd)
 	if err != nil {
 		return err
 	}
 	cmd = "-! " + command + " " + set + " " + ip + "," + "icmpv6:128/0"
+	if timeout != "" {
+		cmd = cmd + " timeout " + timeout
+	}
+
 	log.Println("ipsetHost()", cmd)
 	err = ipsetRun(cmd)
 	if err != nil {
@@ -93,8 +99,10 @@ func ipsetInit(set string) error {
 }
 
 func ipsetInitWithHash(set string, hash string) error {
-	err := ipsetRun("-! create " + set + " hash:" + hash + " family inet6")
+	err := ipsetRun("-! create " + set + " hash:" + hash + " family inet6 counters timeout 0")
 	if err != nil {
+		log.Println("ipsetHost() could not create ipset: ", set)
+		log.Println("Error: ", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
This allows you to make very fine iptables rules (but you have to make
those yourself); also, it is now optional to add the main iptables rule
that allows all traffic to all exposed container ports (so you can be
more specific as to who etc.)
