### PR TITLE
Fix ipv6 - Don't add square brackets every refresh

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	consulapi "github.com/hashicorp/consul/api"
 	"github.com/42wim/registrator-work/bridge"
+	consulapi "github.com/hashicorp/consul/api"
 )
 
 const DefaultInterval = "10s"
@@ -67,7 +67,7 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServiceCheck {
 	check := new(consulapi.AgentServiceCheck)
 	if path := service.Attrs["check_http"]; path != "" {
-		if net.ParseIP(service.IP).To4() == nil { // verify if its an ipv6 address
+		if net.ParseIP(service.IP).To4() == nil && service.IP[0] != '[' { // verify if its an ipv6 address
 			service.IP = fmt.Sprintf("[%s]", service.IP)
 		}
 		check.HTTP = fmt.Sprintf("http://%s:%d%s", service.IP, service.Port, path)


### PR DESCRIPTION
Without this line, ipv6 ip's keep getting more [] around them ... Not
good!
