### PR TITLE
Check if the servicename already has the prefix

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -59,7 +59,7 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 
 	prefix := "" // If the service is hosted on a devbuild server, add a prefix
 	idComponents := strings.Split(service.ID, ":")
-	if len(idComponents) > 0 && strings.Contains(idComponents[0], "devbuild-") {
+	if len(idComponents) > 0 && strings.Contains(idComponents[0], "devbuild-") && !strings.HasPrefix(service.Name, "icts-t-devbuild-") {
 		prefix = "icts-t-devbuild" + "-"
 	}
 


### PR DESCRIPTION
When a container is hosted on devbuild it should be prepended with the
"icts-t-devbuild-" prefix. A check has been proposed here to see if the
prefix is already there. If it is, it should not be added again.